### PR TITLE
fix: Wave 4 audit — 5 verified bugs

### DIFF
--- a/src/color/LUTLoader.test.ts
+++ b/src/color/LUTLoader.test.ts
@@ -3,7 +3,16 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isLUT3D, isLUT1D, parseCubeLUT, applyLUT3D, applyLUT1D, applyLUTToImageData, type LUT3D } from './LUTLoader';
+import {
+  isLUT3D,
+  isLUT1D,
+  parseCubeLUT,
+  applyLUT3D,
+  applyLUT1D,
+  applyLUTToImageData,
+  type LUT3D,
+  type LUT1D,
+} from './LUTLoader';
 import { createSampleCubeLUT, createSample1DLUT } from '../../test/utils';
 
 describe('LUTLoader', () => {
@@ -439,6 +448,191 @@ LUT_1D_SIZE 4
         expect(typeof result[0]).toBe('number');
         expect(typeof result[1]).toBe('number');
         expect(typeof result[2]).toBe('number');
+      });
+    });
+
+    describe('zero-width domain guards (COLOR-W4-02)', () => {
+      it('applyLUT3D returns finite values when domainMin === domainMax on one channel', () => {
+        // Construct a 3D LUT manually with a degenerate red domain
+        const size = 2;
+        const data = new Float32Array(size * size * size * 3);
+        // Identity-ish data
+        let idx = 0;
+        for (let r = 0; r < size; r++) {
+          for (let g = 0; g < size; g++) {
+            for (let b = 0; b < size; b++) {
+              data[idx++] = r / (size - 1);
+              data[idx++] = g / (size - 1);
+              data[idx++] = b / (size - 1);
+            }
+          }
+        }
+        const lut: LUT3D = {
+          type: '3d',
+          title: 'Degenerate Red Domain',
+          size,
+          domainMin: [0.5, 0, 0],
+          domainMax: [0.5, 1, 1], // R range is zero
+          data,
+        };
+
+        const result = applyLUT3D(lut, 0.5, 0.5, 0.5);
+
+        expect(Number.isFinite(result[0])).toBe(true);
+        expect(Number.isFinite(result[1])).toBe(true);
+        expect(Number.isFinite(result[2])).toBe(true);
+      });
+
+      it('applyLUT3D returns finite values when all three channels have zero-width domain', () => {
+        const size = 2;
+        const data = new Float32Array(size * size * size * 3);
+        for (let i = 0; i < data.length; i++) data[i] = 0.42;
+        const lut: LUT3D = {
+          type: '3d',
+          title: 'All Degenerate',
+          size,
+          domainMin: [0.5, 0.5, 0.5],
+          domainMax: [0.5, 0.5, 0.5],
+          data,
+        };
+
+        const result = applyLUT3D(lut, 0.5, 0.5, 0.5);
+
+        expect(Number.isFinite(result[0])).toBe(true);
+        expect(Number.isFinite(result[1])).toBe(true);
+        expect(Number.isFinite(result[2])).toBe(true);
+      });
+
+      it('applyLUT1D returns finite values when domainMin === domainMax on one channel', () => {
+        const size = 4;
+        const data = new Float32Array(size * 3);
+        for (let i = 0; i < size; i++) {
+          const v = i / (size - 1);
+          data[i * 3] = v;
+          data[i * 3 + 1] = v;
+          data[i * 3 + 2] = v;
+        }
+        const lut: LUT1D = {
+          type: '1d',
+          title: 'Degenerate Green Domain',
+          size,
+          domainMin: [0, 0.5, 0],
+          domainMax: [1, 0.5, 1], // G range is zero
+          data,
+        };
+
+        const result = applyLUT1D(lut, 0.5, 0.5, 0.5);
+
+        expect(Number.isFinite(result[0])).toBe(true);
+        expect(Number.isFinite(result[1])).toBe(true);
+        expect(Number.isFinite(result[2])).toBe(true);
+      });
+
+      it('applyLUT1D returns finite values when all three channels have zero-width domain', () => {
+        const size = 4;
+        const data = new Float32Array(size * 3);
+        for (let i = 0; i < size * 3; i++) data[i] = 0.25;
+        const lut: LUT1D = {
+          type: '1d',
+          title: 'All Degenerate 1D',
+          size,
+          domainMin: [0.5, 0.5, 0.5],
+          domainMax: [0.5, 0.5, 0.5],
+          data,
+        };
+
+        const result = applyLUT1D(lut, 0.5, 0.5, 0.5);
+
+        expect(Number.isFinite(result[0])).toBe(true);
+        expect(Number.isFinite(result[1])).toBe(true);
+        expect(Number.isFinite(result[2])).toBe(true);
+      });
+    });
+
+    describe('parser DOMAIN_MIN/MAX validation (COLOR-W4-03)', () => {
+      it('rejects DOMAIN_MIN with non-numeric tokens', () => {
+        const content = `TITLE "Bad Domain"
+LUT_3D_SIZE 2
+DOMAIN_MIN abc def ghi
+DOMAIN_MAX 1.0 1.0 1.0
+0.0 0.0 0.0
+0.5 0.5 0.5
+0.5 0.5 0.5
+1.0 1.0 1.0
+0.5 0.5 0.5
+1.0 1.0 1.0
+1.0 1.0 1.0
+1.0 1.0 1.0`;
+
+        expect(() => parseCubeLUT(content)).toThrow(/Invalid DOMAIN_MIN/);
+      });
+
+      it('rejects DOMAIN_MAX with non-numeric tokens', () => {
+        const content = `TITLE "Bad Domain"
+LUT_3D_SIZE 2
+DOMAIN_MIN 0.0 0.0 0.0
+DOMAIN_MAX foo bar baz
+0.0 0.0 0.0
+0.5 0.5 0.5
+0.5 0.5 0.5
+1.0 1.0 1.0
+0.5 0.5 0.5
+1.0 1.0 1.0
+1.0 1.0 1.0
+1.0 1.0 1.0`;
+
+        expect(() => parseCubeLUT(content)).toThrow(/Invalid DOMAIN_MAX/);
+      });
+
+      it('rejects DOMAIN_MIN with inf/-inf/nan tokens', () => {
+        const content = `TITLE "Inf Domain"
+LUT_3D_SIZE 2
+DOMAIN_MIN inf -inf nan
+DOMAIN_MAX 1.0 1.0 1.0
+0.0 0.0 0.0
+0.5 0.5 0.5
+0.5 0.5 0.5
+1.0 1.0 1.0
+0.5 0.5 0.5
+1.0 1.0 1.0
+1.0 1.0 1.0
+1.0 1.0 1.0`;
+
+        expect(() => parseCubeLUT(content)).toThrow(/Invalid DOMAIN_MIN/);
+      });
+
+      it('rejects DOMAIN_MAX with inf/-inf/nan tokens', () => {
+        const content = `TITLE "Inf Domain"
+LUT_3D_SIZE 2
+DOMAIN_MIN 0.0 0.0 0.0
+DOMAIN_MAX inf -inf nan
+0.0 0.0 0.0
+0.5 0.5 0.5
+0.5 0.5 0.5
+1.0 1.0 1.0
+0.5 0.5 0.5
+1.0 1.0 1.0
+1.0 1.0 1.0
+1.0 1.0 1.0`;
+
+        expect(() => parseCubeLUT(content)).toThrow(/Invalid DOMAIN_MAX/);
+      });
+
+      it('rejects DOMAIN_MIN with one non-finite value', () => {
+        const content = `TITLE "Partial Bad"
+LUT_3D_SIZE 2
+DOMAIN_MIN 0.0 NaN 0.0
+DOMAIN_MAX 1.0 1.0 1.0
+0.0 0.0 0.0
+0.5 0.5 0.5
+0.5 0.5 0.5
+1.0 1.0 1.0
+0.5 0.5 0.5
+1.0 1.0 1.0
+1.0 1.0 1.0
+1.0 1.0 1.0`;
+
+        expect(() => parseCubeLUT(content)).toThrow(/Invalid DOMAIN_MIN/);
       });
     });
 

--- a/src/color/LUTLoader.ts
+++ b/src/color/LUTLoader.ts
@@ -92,17 +92,33 @@ export function parseCubeLUT(content: string): LUT {
     }
 
     if (trimmed.startsWith('DOMAIN_MIN')) {
-      const match = trimmed.match(/DOMAIN_MIN\s+([\d.-]+)\s+([\d.-]+)\s+([\d.-]+)/i);
+      const match = trimmed.match(/DOMAIN_MIN\s+(\S+)\s+(\S+)\s+(\S+)/i);
       if (match) {
-        domainMin = [parseFloat(match[1]!), parseFloat(match[2]!), parseFloat(match[3]!)];
+        const v0 = parseFloat(match[1]!);
+        const v1 = parseFloat(match[2]!);
+        const v2 = parseFloat(match[3]!);
+        if (!Number.isFinite(v0) || !Number.isFinite(v1) || !Number.isFinite(v2)) {
+          throw new Error(
+            `Invalid DOMAIN_MIN values: "${match[1]} ${match[2]} ${match[3]}" (expected three finite numbers)`,
+          );
+        }
+        domainMin = [v0, v1, v2];
       }
       continue;
     }
 
     if (trimmed.startsWith('DOMAIN_MAX')) {
-      const match = trimmed.match(/DOMAIN_MAX\s+([\d.-]+)\s+([\d.-]+)\s+([\d.-]+)/i);
+      const match = trimmed.match(/DOMAIN_MAX\s+(\S+)\s+(\S+)\s+(\S+)/i);
       if (match) {
-        domainMax = [parseFloat(match[1]!), parseFloat(match[2]!), parseFloat(match[3]!)];
+        const v0 = parseFloat(match[1]!);
+        const v1 = parseFloat(match[2]!);
+        const v2 = parseFloat(match[3]!);
+        if (!Number.isFinite(v0) || !Number.isFinite(v1) || !Number.isFinite(v2)) {
+          throw new Error(
+            `Invalid DOMAIN_MAX values: "${match[1]} ${match[2]} ${match[3]}" (expected three finite numbers)`,
+          );
+        }
+        domainMax = [v0, v1, v2];
       }
       continue;
     }
@@ -179,9 +195,13 @@ export function applyLUT3D(lut: LUT3D, r: number, g: number, b: number): [number
   const { size, domainMin, domainMax, data } = lut;
 
   // Normalize input to 0-1 range based on domain
-  const nr = (r - domainMin[0]) / (domainMax[0] - domainMin[0]);
-  const ng = (g - domainMin[1]) / (domainMax[1] - domainMin[1]);
-  const nb = (b - domainMin[2]) / (domainMax[2] - domainMin[2]);
+  // Guard against zero-width domain (domainMin === domainMax)
+  const rangeR = domainMax[0] - domainMin[0];
+  const rangeG = domainMax[1] - domainMin[1];
+  const rangeB = domainMax[2] - domainMin[2];
+  const nr = rangeR === 0 ? 0 : (r - domainMin[0]) / rangeR;
+  const ng = rangeG === 0 ? 0 : (g - domainMin[1]) / rangeG;
+  const nb = rangeB === 0 ? 0 : (b - domainMin[2]) / rangeB;
 
   // Clamp and scale to LUT indices
   const maxIdx = size - 1;
@@ -247,7 +267,9 @@ export function applyLUT1D(lut: LUT1D, r: number, g: number, b: number): [number
   // Helper to apply 1D LUT to a single channel
   const applyChannel = (value: number, channelOffset: number, domainMinCh: number, domainMaxCh: number): number => {
     // Normalize input to 0-1 range based on domain
-    const normalized = (value - domainMinCh) / (domainMaxCh - domainMinCh);
+    // Guard against zero-width domain (domainMin === domainMax)
+    const range = domainMaxCh - domainMinCh;
+    const normalized = range === 0 ? 0 : (value - domainMinCh) / range;
 
     // Clamp and scale to LUT indices
     const maxIdx = size - 1;

--- a/src/core/session/PlaybackEngine.test.ts
+++ b/src/core/session/PlaybackEngine.test.ts
@@ -1414,4 +1414,232 @@ describe('PlaybackEngine', () => {
       expect(engine.isStarved).toBe(false);
     });
   });
+
+  // ---------------------------------------------------------------
+  // SESSION-W4-01: stale getFrameAsync callback guard
+  // ---------------------------------------------------------------
+  describe('SESSION-W4-01: stale getFrameAsync callback guard', () => {
+    type DeferredVoid = {
+      promise: Promise<void>;
+      resolve: () => void;
+      reject: (err: unknown) => void;
+    };
+
+    const createDeferred = (): DeferredVoid => {
+      let resolve!: () => void;
+      let reject!: (err: unknown) => void;
+      const promise = new Promise<void>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    };
+
+    type MockVideoSourceNode = {
+      isUsingMediabunny: () => boolean;
+      hasFrameCached: () => boolean;
+      getFrameAsync: ReturnType<typeof vi.fn>;
+      updatePlaybackBuffer: ReturnType<typeof vi.fn>;
+      startPlaybackPreload: ReturnType<typeof vi.fn>;
+      stopPlaybackPreload: ReturnType<typeof vi.fn>;
+      setPlaybackDirection: ReturnType<typeof vi.fn>;
+      preloadFrames: () => Promise<void>;
+      isHDR: () => boolean;
+    };
+
+    type MockSource = {
+      type: 'video';
+      name: string;
+      url: string;
+      width: number;
+      height: number;
+      duration: number;
+      fps: number;
+      element: HTMLVideoElement | undefined;
+      videoSourceNode: MockVideoSourceNode;
+    };
+
+    const createMockVideoSourceNode = (deferred: DeferredVoid): MockVideoSourceNode => ({
+      isUsingMediabunny: () => true,
+      hasFrameCached: () => false,
+      getFrameAsync: vi.fn().mockReturnValue(deferred.promise),
+      updatePlaybackBuffer: vi.fn(),
+      startPlaybackPreload: vi.fn(),
+      stopPlaybackPreload: vi.fn(),
+      setPlaybackDirection: vi.fn(),
+      preloadFrames: () => Promise.resolve(),
+      isHDR: () => false,
+    });
+
+    const createMockSource = (
+      name: string,
+      videoSourceNode: MockVideoSourceNode,
+    ): MockSource => ({
+      type: 'video',
+      name,
+      url: `file:///${name}`,
+      width: 1920,
+      height: 1080,
+      duration: 100,
+      fps: 24,
+      element: undefined,
+      videoSourceNode,
+    });
+
+    /**
+     * Sets up a host whose currentSource is read from a mutable ref, primes
+     * the engine with an in-flight fetch against the initial source, and
+     * returns helpers so the test can swap sources or resolve/reject the
+     * fetch on demand.
+     */
+    const setupInFlightFetch = (): {
+      deferred: DeferredVoid;
+      initialNode: MockVideoSourceNode;
+      initialSource: MockSource;
+      sourceRef: { value: MockSource };
+      perfNowSpy: ReturnType<typeof vi.spyOn>;
+    } => {
+      const deferred = createDeferred();
+      const initialNode = createMockVideoSourceNode(deferred);
+      const initialSource = createMockSource('initial.mp4', initialNode);
+      const sourceRef: { value: MockSource } = { value: initialSource };
+
+      const customHost = {
+        ...createMockPlaybackEngineHost(100),
+        getCurrentSource: () => sourceRef.value as never,
+      };
+      engine.setHost(customHost as PlaybackEngineHost);
+      engine.setOutPointInternal(100);
+
+      const perfNowSpy = vi.spyOn(performance, 'now');
+      perfNowSpy.mockReturnValue(1000);
+      engine.play();
+      // Give the timing controller enough delta (>= one frame at 24fps) to
+      // enter the while-loop and reach the getFrameAsync branch, but stay
+      // well under STARVATION_TIMEOUT_MS so we don't trip starvation.
+      perfNowSpy.mockReturnValue(1100);
+      engine.update();
+
+      // Sanity: the fetch went out against the initial source's node (the
+      // exact call count is not asserted because triggerInitialBufferLoad
+      // also calls getFrameAsync to preload upcoming frames) and we are now
+      // in a buffering state.
+      expect((initialNode.getFrameAsync as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+      expect(initialNode.updatePlaybackBuffer).not.toHaveBeenCalled();
+
+      return { deferred, initialNode, initialSource, sourceRef, perfNowSpy };
+    };
+
+    it('SESSION-W4-01: stale callback after source switch does NOT touch any buffer', async () => {
+      const { deferred, initialNode, sourceRef, perfNowSpy } = setupInFlightFetch();
+
+      // Simulate the user switching sources mid-flight.
+      const newNode = createMockVideoSourceNode(createDeferred());
+      const newSource = createMockSource('switched.mp4', newNode);
+      sourceRef.value = newSource;
+
+      // Resolve the in-flight fetch.
+      deferred.resolve();
+      await deferred.promise;
+      // Drain microtasks (the .then chain).
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The stale callback must NOT touch either source's buffer.
+      expect(newNode.updatePlaybackBuffer).not.toHaveBeenCalled();
+      expect(initialNode.updatePlaybackBuffer).not.toHaveBeenCalled();
+
+      perfNowSpy.mockRestore();
+    });
+
+    it('SESSION-W4-01: stale callback still decrements buffering count (success path)', async () => {
+      const { deferred, sourceRef, perfNowSpy } = setupInFlightFetch();
+
+      const tcState = (engine as unknown as { _ts: { bufferingCount: number } })._ts;
+      const bufferingCountBefore = tcState.bufferingCount;
+      expect(bufferingCountBefore).toBeGreaterThan(0);
+
+      // Swap the source to make the in-flight callback stale.
+      const newNode = createMockVideoSourceNode(createDeferred());
+      sourceRef.value = createMockSource('switched.mp4', newNode);
+
+      deferred.resolve();
+      await deferred.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The stale callback must still balance the buffering increment.
+      expect(tcState.bufferingCount).toBe(bufferingCountBefore - 1);
+
+      perfNowSpy.mockRestore();
+    });
+
+    it('SESSION-W4-01: stale callback still decrements buffering count (error path)', async () => {
+      const { deferred, initialNode, sourceRef, perfNowSpy } = setupInFlightFetch();
+
+      const tcState = (engine as unknown as { _ts: { bufferingCount: number } })._ts;
+      const bufferingCountBefore = tcState.bufferingCount;
+      expect(bufferingCountBefore).toBeGreaterThan(0);
+
+      const newNode = createMockVideoSourceNode(createDeferred());
+      sourceRef.value = createMockSource('switched.mp4', newNode);
+
+      deferred.reject(new Error('decode failed'));
+      await deferred.promise.catch(() => {});
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(tcState.bufferingCount).toBe(bufferingCountBefore - 1);
+      // No source's buffer should have been touched.
+      expect(newNode.updatePlaybackBuffer).not.toHaveBeenCalled();
+      expect(initialNode.updatePlaybackBuffer).not.toHaveBeenCalled();
+
+      perfNowSpy.mockRestore();
+    });
+
+    it('SESSION-W4-01: happy path still calls updatePlaybackBuffer and clears _pendingFetchFrame', async () => {
+      const { deferred, initialNode, perfNowSpy } = setupInFlightFetch();
+
+      // _pendingFetchFrame is set to the frame being fetched (must match
+      // the value passed to the live update() fetch — which is the engine's
+      // pendingFetchFrame).
+      const requestedFrame = engine.pendingFetchFrame;
+      expect(requestedFrame).not.toBeNull();
+
+      const tcState = (engine as unknown as { _ts: { bufferingCount: number } })._ts;
+      const bufferingCountBefore = tcState.bufferingCount;
+
+      // Resolve the fetch — source has NOT changed, so the callback is fresh.
+      deferred.resolve();
+      await deferred.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(initialNode.updatePlaybackBuffer).toHaveBeenCalledWith(requestedFrame);
+      expect(tcState.bufferingCount).toBe(bufferingCountBefore - 1);
+      // _pendingFetchFrame must be cleared on success so the next tick can
+      // re-issue a fetch if the cache still doesn't contain the frame.
+      expect(engine.pendingFetchFrame).toBeNull();
+
+      perfNowSpy.mockRestore();
+    });
+
+    it('SESSION-W4-01: dispose between fetch and resolution skips updatePlaybackBuffer', async () => {
+      const { deferred, initialNode, perfNowSpy } = setupInFlightFetch();
+
+      // Dispose the engine while the fetch is in flight.
+      engine.dispose();
+
+      // Resolve the (now-stale) fetch.
+      deferred.resolve();
+      await deferred.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // No buffer mutation should have happened on the disposed engine.
+      expect(initialNode.updatePlaybackBuffer).not.toHaveBeenCalled();
+
+      perfNowSpy.mockRestore();
+    });
+  });
 });

--- a/src/core/session/PlaybackEngine.test.ts
+++ b/src/core/session/PlaybackEngine.test.ts
@@ -1471,10 +1471,7 @@ describe('PlaybackEngine', () => {
       isHDR: () => false,
     });
 
-    const createMockSource = (
-      name: string,
-      videoSourceNode: MockVideoSourceNode,
-    ): MockSource => ({
+    const createMockSource = (name: string, videoSourceNode: MockVideoSourceNode): MockSource => ({
       type: 'video',
       name,
       url: `file:///${name}`,

--- a/src/core/session/PlaybackEngine.ts
+++ b/src/core/session/PlaybackEngine.ts
@@ -951,16 +951,51 @@ export class PlaybackEngine extends EventEmitter<PlaybackEngineEvents> {
             this.emit('buffering', true);
           }
 
-          videoSourceNode
-            .getFrameAsync(nextFrame)
+          // Capture refs locally so the async callback can detect a stale fetch
+          // (source switch, supersession by a newer fetch, or engine disposal)
+          // before mutating buffer state belonging to the wrong source.
+          const fetchSource = source;
+          const fetchVideoSourceNode = videoSourceNode;
+          const fetchFrame = nextFrame;
+
+          const isStillRelevant = (): boolean => {
+            // Engine disposed (dispose() nulls out _host)
+            if (!this._host) return false;
+            // A newer fetch superseded this one (or _pendingFetchFrame was
+            // cleared by pause()/starvation/cache-hit handling)
+            if (this._pendingFetchFrame !== fetchFrame) return false;
+            // The current source / video source node changed under us
+            const currentSource = this._host.getCurrentSource();
+            if (currentSource !== fetchSource) return false;
+            if (currentSource?.videoSourceNode !== fetchVideoSourceNode) return false;
+            return true;
+          };
+
+          fetchVideoSourceNode
+            .getFrameAsync(fetchFrame)
             .then(() => {
-              source.videoSourceNode?.updatePlaybackBuffer(nextFrame);
-              this.updateSourceBPlaybackBuffer(nextFrame);
+              if (!isStillRelevant()) {
+                // Stale resolution — still balance the buffering increment,
+                // but do NOT touch any buffer state (which may belong to a
+                // different source now).
+                this.decrementBufferingCount();
+                return;
+              }
+              fetchSource.videoSourceNode?.updatePlaybackBuffer(fetchFrame);
+              this.updateSourceBPlaybackBuffer(fetchFrame);
+              // Clear the pending marker so the next tick can issue a fresh
+              // fetch if needed (otherwise we could short-circuit the
+              // `_pendingFetchFrame !== nextFrame` guard above).
+              this._pendingFetchFrame = null;
               this.decrementBufferingCount();
             })
             .catch((err) => {
               if (err?.name !== 'AbortError') {
                 log.warn('Frame fetch error:', err);
+              }
+              // Always balance the buffering counter, even if stale.
+              if (isStillRelevant()) {
+                this._pendingFetchFrame = null;
               }
               this.decrementBufferingCount();
             });

--- a/src/nodes/base/IPNode.test.ts
+++ b/src/nodes/base/IPNode.test.ts
@@ -29,7 +29,7 @@ describe('IPNode', () => {
       // Verify the forwarding works before dispose
       prop.value = 0.5;
       expect(listener).toHaveBeenCalledTimes(1);
-      expect(listener).toHaveBeenCalledWith({ name: 'opacity', value: 0.5 }, { name: 'opacity', value: 0.5 });
+      expect(listener).toHaveBeenCalledWith({ name: 'opacity', value: 0.5 }, { name: 'opacity', value: 1.0 });
 
       // Dispose the node
       node.dispose();
@@ -40,6 +40,33 @@ describe('IPNode', () => {
 
       // Listener should NOT have been called after dispose
       expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('NODE-W4-06: propertyChanged forwards oldValue (not duplicated newValue) to subscribers', () => {
+      const node = new TestNode('oldValueTest');
+      const prop = node.properties.add({ name: 'gain', defaultValue: 1.0 });
+
+      const listener = vi.fn();
+      node.propertyChanged.connect(listener);
+
+      // First change: 1.0 -> 2.5
+      prop.value = 2.5;
+      expect(listener).toHaveBeenCalledTimes(1);
+      const [firstNew, firstOld] = listener.mock.calls[0]!;
+      expect(firstNew).toEqual({ name: 'gain', value: 2.5 });
+      expect(firstOld).toEqual({ name: 'gain', value: 1.0 });
+      // Critical: ensure the oldValue object is NOT identical to newValue (the original bug)
+      expect(firstOld).not.toBe(firstNew);
+      expect((firstOld as { value: unknown }).value).not.toBe((firstNew as { value: unknown }).value);
+
+      // Second change: 2.5 -> 3.0; oldValue should reflect 2.5, not 3.0
+      prop.value = 3.0;
+      expect(listener).toHaveBeenCalledTimes(2);
+      const [secondNew, secondOld] = listener.mock.calls[1]!;
+      expect(secondNew).toEqual({ name: 'gain', value: 3.0 });
+      expect(secondOld).toEqual({ name: 'gain', value: 2.5 });
+
+      node.dispose();
     });
 
     it('IPNODE-DISP-002: after dispose(), properties.propertyChanged has no connections (forwarding subscription removed)', () => {

--- a/src/nodes/base/IPNode.ts
+++ b/src/nodes/base/IPNode.ts
@@ -55,9 +55,9 @@ export abstract class IPNode {
     this.properties = new PropertyContainer();
 
     // Forward property changes
-    this.properties.propertyChanged.connect((data) => {
+    this.properties.propertyChanged.connect((data, oldData) => {
       this.markDirty();
-      this.propertyChanged.emit(data, data);
+      this.propertyChanged.emit(data, oldData);
     });
   }
 

--- a/src/plugin/PluginRegistry.test.ts
+++ b/src/plugin/PluginRegistry.test.ts
@@ -346,6 +346,50 @@ describe('PluginRegistry', () => {
       await registry.activateAll();
       expect(order).toEqual(['a', 'b']);
     });
+
+    it('PLUGIN-W4-01: activateAll skips already-disposed plugins', async () => {
+      const activateA = vi.fn();
+      const activateB = vi.fn();
+      const pluginA = createPlugin({
+        manifest: { id: 'a', name: 'A', version: '1.0.0', contributes: ['decoder'] },
+        activate: activateA,
+      });
+      const pluginB = createPlugin({
+        manifest: { id: 'b', name: 'B', version: '1.0.0', contributes: ['decoder'] },
+        activate: activateB,
+      });
+      registry.register(pluginA);
+      registry.register(pluginB);
+      // Dispose A before activateAll runs — A must not be re-activated, and B
+      // (which has no deps) must still come up cleanly. This exercises the
+      // topologicalSort() filter: if A leaked into the sorted output, the
+      // activate(a) call would throw "cannot be reactivated" and abort.
+      await registry.dispose('a');
+      await registry.activateAll();
+      expect(activateA).not.toHaveBeenCalled();
+      expect(activateB).toHaveBeenCalledTimes(1);
+      expect(registry.getState('a')).toBe('disposed');
+      expect(registry.getState('b')).toBe('active');
+    });
+
+    it('PLUGIN-W4-01: activate throws clear "disposed" error when dep is disposed', async () => {
+      const pluginA = createPlugin({
+        manifest: { id: 'a', name: 'A', version: '1.0.0', contributes: ['decoder'] },
+        activate: vi.fn(),
+      });
+      const pluginB = createPlugin({
+        manifest: { id: 'b', name: 'B', version: '1.0.0', contributes: ['decoder'], dependencies: ['a'] },
+        activate: vi.fn(),
+      });
+      registry.register(pluginA);
+      registry.register(pluginB);
+      await registry.dispose('a');
+      // Must surface the disposed-dep cause directly, not the generic
+      // "not registered" message and not the misleading
+      // "has been disposed and cannot be reactivated" message from the
+      // recursive activate(depId) call.
+      await expect(registry.activate('b')).rejects.toThrow('"b" depends on "a" which is disposed');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/plugin/PluginRegistry.ts
+++ b/src/plugin/PluginRegistry.ts
@@ -224,6 +224,14 @@ export class PluginRegistry {
     for (const depId of entry.plugin.manifest.dependencies ?? []) {
       const dep = this.plugins.get(depId);
       if (!dep) throw new Error(`Plugin "${id}" depends on "${depId}" which is not registered`);
+      // A disposed dependency is effectively no longer available — treat it
+      // distinctly from "not registered" so the error points at the real cause
+      // and we do not attempt to reactivate a disposed plugin (which would
+      // throw a misleading "cannot be reactivated" error from a different code
+      // path).
+      if (dep.state === 'disposed') {
+        throw new Error(`Plugin "${id}" depends on "${depId}" which is disposed`);
+      }
       if (dep.state !== 'active') {
         await this.activate(depId);
       }
@@ -580,7 +588,18 @@ export class PluginRegistry {
       }
       inProgress.add(id);
       const entry = this.plugins.get(id);
-      if (!entry) return;
+      if (!entry) {
+        inProgress.delete(id);
+        return;
+      }
+      // Skip disposed plugins: they remain in the Map (so getState() still
+      // reports 'disposed') but must never appear in the sorted output, since
+      // callers like activateAll() and the dependency walker in activate()
+      // rely on the result containing only live plugins.
+      if (entry.state === 'disposed') {
+        inProgress.delete(id);
+        return;
+      }
       for (const dep of entry.plugin.manifest.dependencies ?? []) {
         visit(dep);
       }

--- a/src/render/webgpu/WebGPUStateUploader.test.ts
+++ b/src/render/webgpu/WebGPUStateUploader.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { WebGPUStateUploader, STAGE_FIELDS, DIRTY_FLAG_TO_STAGES } from './WebGPUStateUploader';
+import {
+  WebGPUStateUploader,
+  STAGE_FIELDS,
+  DIRTY_FLAG_TO_STAGES,
+  SCENE_ANALYSIS_OFFSETS,
+  SCENE_ANALYSIS_BYTE_SIZE,
+} from './WebGPUStateUploader';
+import { TONE_MAPPING_OPERATOR_CODES } from '../ShaderConstants';
 import { GPUBufferUsage, GPUTextureUsage } from './WebGPUTypes';
 import { createDefaultInternalState } from '../ShaderStateTypes';
 import type { InternalShaderState } from '../ShaderStateTypes';
@@ -354,16 +361,112 @@ describe('WebGPUStateUploader', () => {
     it('WGPU-SU-137: sceneAnalysis packs outOfRange (i32) and toneMappingState (i32)', () => {
       state.outOfRange = 2;
       state.toneMappingState.enabled = true;
+      state.toneMappingState.operator = 'aces'; // -> code 3
       state.gamutMappingEnabled = true;
       state.gamutMappingModeCode = 1;
 
       uploader.uploadStageUniforms(device, 'sceneAnalysis', state);
 
       const view = getUploadedView(device);
-      expect(readI32(view, 0)).toBe(2); // outOfRange as i32
-      expect(readI32(view, 1)).toBe(1); // toneMappingState.enabled as i32
-      expect(readI32(view, 2)).toBe(1); // gamutMappingEnabled as i32
-      expect(readI32(view, 3)).toBe(1); // gamutMappingModeCode as i32
+      // Offsets per scene_analysis.wgsl Uniforms struct order:
+      expect(readI32(view, 0)).toBe(2); // outOfRange (slot 0)
+      expect(readI32(view, 1)).toBe(1); // toneMappingState.enabled (slot 1)
+      expect(readI32(view, 2)).toBe(3); // toneMappingOperator (slot 2) -- aces
+      // hdrHeadroom (slot 3) defaults to 1.0
+      // gamutMappingEnabled now lives at slot 12 (byte offset 48)
+      expect(readI32(view, 12)).toBe(1); // gamutMappingEnabled
+      expect(readI32(view, 13)).toBe(1); // gamutMappingModeCode
+    });
+  });
+
+  // ─── RENDER-W4-01 regression: pin scene_analysis.wgsl byte layout ────
+
+  describe('sceneAnalysis byte layout (RENDER-W4-01)', () => {
+    /**
+     * Read a 4-byte slot at the named offset, asserting the layout matches
+     * the WGSL `Uniforms` struct in src/render/webgpu/shaders/scene_analysis.wgsl.
+     *
+     * If a future edit drifts the pack order from the WGSL struct order, this
+     * test will fail and the diff will point at the misaligned field — preventing
+     * a recurrence of the bug where toneMappingOperator got gamutMappingEnabled's
+     * value and hdrHeadroom + _pad0 were skipped entirely.
+     */
+    it('WGPU-SU-138: SCENE_ANALYSIS_OFFSETS map is monotonically increasing 4-byte slots', () => {
+      const entries = Object.entries(SCENE_ANALYSIS_OFFSETS);
+      for (let i = 0; i < entries.length; i++) {
+        expect(entries[i]![1]).toBe(i * 4);
+      }
+      // Trailing _pad3 lives at offset 76; struct total is 80 bytes.
+      expect(SCENE_ANALYSIS_BYTE_SIZE).toBe(76 + 4);
+    });
+
+    it('WGPU-SU-139: writes every field at the offset declared by SCENE_ANALYSIS_OFFSETS', () => {
+      // Assign distinct, recoverable values to every WGSL field so that
+      // a swap or skip in pack order is caught by the readback below.
+      state.outOfRange = 2;
+      state.toneMappingState.enabled = true;
+      state.toneMappingState.operator = 'drago'; // -> code 8
+      state.toneMappingState.reinhardWhitePoint = 4.5;
+      state.toneMappingState.filmicExposureBias = 2.5;
+      state.toneMappingState.filmicWhitePoint = 11.5;
+      state.toneMappingState.dragoBias = 0.9;
+      state.toneMappingState.dragoLwa = 0.25;
+      state.toneMappingState.dragoLmax = 1.75;
+      state.toneMappingState.dragoBrightness = 2.25;
+      state.gamutMappingEnabled = true;
+      state.gamutMappingModeCode = 1;
+      state.gamutSourceCode = 2;
+      state.gamutTargetCode = 1;
+      state.gamutHighlightEnabled = true;
+
+      uploader.setHDRHeadroom(3.5);
+      uploader.uploadStageUniforms(device, 'sceneAnalysis', state);
+
+      const view = getUploadedView(device);
+      const i32 = (offset: number): number => view.getInt32(offset, true);
+      const f32 = (offset: number): number => view.getFloat32(offset, true);
+
+      expect(i32(SCENE_ANALYSIS_OFFSETS.outOfRange)).toBe(2);
+      expect(i32(SCENE_ANALYSIS_OFFSETS.toneMappingEnabled)).toBe(1);
+      expect(i32(SCENE_ANALYSIS_OFFSETS.toneMappingOperator)).toBe(TONE_MAPPING_OPERATOR_CODES.drago);
+      expect(f32(SCENE_ANALYSIS_OFFSETS.hdrHeadroom)).toBeCloseTo(3.5);
+      expect(f32(SCENE_ANALYSIS_OFFSETS.tmReinhardWhitePoint)).toBeCloseTo(4.5);
+      expect(f32(SCENE_ANALYSIS_OFFSETS._pad0)).toBe(0); // pad MUST be zero
+      expect(f32(SCENE_ANALYSIS_OFFSETS.tmFilmicExposureBias)).toBeCloseTo(2.5);
+      expect(f32(SCENE_ANALYSIS_OFFSETS.tmFilmicWhitePoint)).toBeCloseTo(11.5);
+      expect(f32(SCENE_ANALYSIS_OFFSETS.tmDragoBias)).toBeCloseTo(0.9);
+      expect(f32(SCENE_ANALYSIS_OFFSETS.tmDragoLwa)).toBeCloseTo(0.25);
+      expect(f32(SCENE_ANALYSIS_OFFSETS.tmDragoLmax)).toBeCloseTo(1.75);
+      expect(f32(SCENE_ANALYSIS_OFFSETS.tmDragoBrightness)).toBeCloseTo(2.25);
+      expect(i32(SCENE_ANALYSIS_OFFSETS.gamutMappingEnabled)).toBe(1);
+      expect(i32(SCENE_ANALYSIS_OFFSETS.gamutMappingModeCode)).toBe(1);
+      expect(i32(SCENE_ANALYSIS_OFFSETS.gamutSourceCode)).toBe(2);
+      expect(i32(SCENE_ANALYSIS_OFFSETS.gamutTargetCode)).toBe(1);
+      expect(i32(SCENE_ANALYSIS_OFFSETS.gamutHighlightEnabled)).toBe(1);
+      expect(i32(SCENE_ANALYSIS_OFFSETS._pad1)).toBe(0);
+      expect(i32(SCENE_ANALYSIS_OFFSETS._pad2)).toBe(0);
+      expect(i32(SCENE_ANALYSIS_OFFSETS._pad3)).toBe(0);
+    });
+
+    it('WGPU-SU-13A: toneMappingOperator is 0 when tone mapping is disabled (regardless of operator string)', () => {
+      state.toneMappingState.enabled = false;
+      state.toneMappingState.operator = 'drago'; // would be code 8 if enabled
+      uploader.uploadStageUniforms(device, 'sceneAnalysis', state);
+
+      const view = getUploadedView(device);
+      expect(view.getInt32(SCENE_ANALYSIS_OFFSETS.toneMappingEnabled, true)).toBe(0);
+      expect(view.getInt32(SCENE_ANALYSIS_OFFSETS.toneMappingOperator, true)).toBe(0);
+    });
+
+    it('WGPU-SU-13B: setHDRHeadroom clamps non-finite to 1.0 and finite to [1, 100]', () => {
+      uploader.setHDRHeadroom(Number.NaN);
+      expect(uploader.getHDRHeadroom()).toBe(1.0);
+      uploader.setHDRHeadroom(0.5);
+      expect(uploader.getHDRHeadroom()).toBe(1.0);
+      uploader.setHDRHeadroom(150);
+      expect(uploader.getHDRHeadroom()).toBe(100);
+      uploader.setHDRHeadroom(5);
+      expect(uploader.getHDRHeadroom()).toBe(5);
     });
   });
 

--- a/src/render/webgpu/WebGPUStateUploader.ts
+++ b/src/render/webgpu/WebGPUStateUploader.ts
@@ -15,6 +15,7 @@
 
 import type { InternalShaderState } from '../ShaderStateTypes';
 import type { StageId } from '../ShaderStage';
+import { TONE_MAPPING_OPERATOR_CODES } from '../ShaderConstants';
 import type { WGPUDevice, WGPUBuffer, WGPUTexture } from './WebGPUTypes';
 import { GPUBufferUsage, GPUTextureUsage } from './WebGPUTypes';
 
@@ -291,6 +292,42 @@ function packMat3(view: DataView, offset: number, mat: Float32Array): number {
 }
 
 // ---------------------------------------------------------------------------
+// Scene-analysis byte layout — pinned to scene_analysis.wgsl Uniforms struct.
+//
+// All fields are 4 bytes (i32 or f32) so byte offset = slot * 4. The named
+// constants below MUST stay in sync with the WGSL `Uniforms` struct in
+// src/render/webgpu/shaders/scene_analysis.wgsl. Tests reference these to
+// pin the layout; bumping a slot here without bumping the WGSL counterpart
+// will fail the regression test.
+// ---------------------------------------------------------------------------
+
+export const SCENE_ANALYSIS_OFFSETS = {
+  outOfRange: 0,
+  toneMappingEnabled: 4,
+  toneMappingOperator: 8,
+  hdrHeadroom: 12,
+  tmReinhardWhitePoint: 16,
+  _pad0: 20,
+  tmFilmicExposureBias: 24,
+  tmFilmicWhitePoint: 28,
+  tmDragoBias: 32,
+  tmDragoLwa: 36,
+  tmDragoLmax: 40,
+  tmDragoBrightness: 44,
+  gamutMappingEnabled: 48,
+  gamutMappingModeCode: 52,
+  gamutSourceCode: 56,
+  gamutTargetCode: 60,
+  gamutHighlightEnabled: 64,
+  _pad1: 68,
+  _pad2: 72,
+  _pad3: 76,
+} as const;
+
+/** Total byte size of the scene-analysis uniform struct (after final pad). */
+export const SCENE_ANALYSIS_BYTE_SIZE = 80;
+
+// ---------------------------------------------------------------------------
 // WebGPUStateUploader
 // ---------------------------------------------------------------------------
 
@@ -306,6 +343,35 @@ export class WebGPUStateUploader {
 
   /** Maximum uniform buffer size per stage (generous default). */
   private static readonly MAX_STAGE_BUFFER_SIZE = 512;
+
+  /**
+   * HDR headroom value used when packing the sceneAnalysis stage.
+   *
+   * `hdrHeadroom` lives in the per-stage `Uniforms` struct in
+   * scene_analysis.wgsl but does not exist on InternalShaderState (it is
+   * managed at the pipeline level — see WebGPUShaderPipeline.setGlobalHDRHeadroom).
+   * Callers thread the runtime value in via setHDRHeadroom() so the WGSL
+   * uniform has the correct value at upload time. Defaults to 1.0 (SDR).
+   */
+  private hdrHeadroom = 1.0;
+
+  /**
+   * Set the HDR headroom value used when packing the sceneAnalysis uniforms.
+   * Mirrors the contract of WebGPUShaderPipeline.setGlobalHDRHeadroom:
+   * non-finite values become 1.0; finite values are clamped to [1, 100].
+   */
+  setHDRHeadroom(headroom: number): void {
+    if (!Number.isFinite(headroom)) {
+      this.hdrHeadroom = 1.0;
+      return;
+    }
+    this.hdrHeadroom = Math.min(100.0, Math.max(1.0, headroom));
+  }
+
+  /** Get the current HDR headroom value. */
+  getHDRHeadroom(): number {
+    return this.hdrHeadroom;
+  }
 
   /**
    * Upload uniform data for a specific stage.
@@ -650,29 +716,43 @@ export class WebGPUStateUploader {
     packVec3(view, off, state.fileLUT3DDomainMax[0], state.fileLUT3DDomainMax[1], state.fileLUT3DDomainMax[2]);
   }
 
-  // WGSL struct: outOfRange: i32, toneMappingEnabled: i32, toneMappingOperator: i32,
-  //   hdrHeadroom: f32, tmReinhardWhitePoint: f32, _pad0: f32, tmFilmicExposureBias: f32,
-  //   tmFilmicWhitePoint: f32, tmDragoBias: f32, tmDragoLwa: f32, tmDragoLmax: f32,
-  //   tmDragoBrightness: f32, gamutMappingEnabled: i32, gamutMappingModeCode: i32,
-  //   gamutSourceCode: i32, gamutTargetCode: i32, gamutHighlightEnabled: i32, ...
+  // Layout MUST match scene_analysis.wgsl Uniforms struct exactly:
+  //   outOfRange: i32, toneMappingEnabled: i32, toneMappingOperator: i32,
+  //   hdrHeadroom: f32, tmReinhardWhitePoint: f32, _pad0: f32,
+  //   tmFilmicExposureBias: f32, tmFilmicWhitePoint: f32,
+  //   tmDragoBias: f32, tmDragoLwa: f32, tmDragoLmax: f32, tmDragoBrightness: f32,
+  //   gamutMappingEnabled: i32, gamutMappingModeCode: i32, gamutSourceCode: i32,
+  //   gamutTargetCode: i32, gamutHighlightEnabled: i32, _pad1: i32, _pad2: i32, _pad3: i32
+  //
+  // Named offsets are exported as SCENE_ANALYSIS_OFFSETS — pinned by tests.
+  // hdrHeadroom is sourced from this.hdrHeadroom because it is not a member
+  // of InternalShaderState — see setHDRHeadroom() above.
   private packSceneAnalysis(view: DataView, state: Readonly<InternalShaderState>): void {
     const tm = state.toneMappingState;
+    // Convert string operator to int code; force 0 when disabled so the
+    // shader can dispatch on the operator alone (matches WebGL ShaderUniformUploader).
+    const operatorCode = tm.enabled ? TONE_MAPPING_OPERATOR_CODES[tm.operator] : 0;
     let off = 0;
     off = packI32(view, off, state.outOfRange);
     off = packI32(view, off, tm.enabled ? 1 : 0);
-    off = packI32(view, off, state.gamutMappingEnabled ? 1 : 0);
-    off = packI32(view, off, state.gamutMappingModeCode);
-    off = packI32(view, off, state.gamutSourceCode);
-    off = packI32(view, off, state.gamutTargetCode);
-    off = packI32(view, off, state.gamutHighlightEnabled ? 1 : 0);
-    // Tone mapping params follow
+    off = packI32(view, off, operatorCode);
+    off = packFloat(view, off, this.hdrHeadroom);
     off = packFloat(view, off, tm.reinhardWhitePoint ?? 4.0);
+    off = packFloat(view, off, 0); // _pad0
     off = packFloat(view, off, tm.filmicExposureBias ?? 2.0);
     off = packFloat(view, off, tm.filmicWhitePoint ?? 11.2);
     off = packFloat(view, off, tm.dragoBias ?? 0.85);
     off = packFloat(view, off, tm.dragoLwa ?? 0.2);
     off = packFloat(view, off, tm.dragoLmax ?? 1.5);
-    packFloat(view, off, tm.dragoBrightness ?? 2.0);
+    off = packFloat(view, off, tm.dragoBrightness ?? 2.0);
+    off = packI32(view, off, state.gamutMappingEnabled ? 1 : 0);
+    off = packI32(view, off, state.gamutMappingModeCode);
+    off = packI32(view, off, state.gamutSourceCode);
+    off = packI32(view, off, state.gamutTargetCode);
+    off = packI32(view, off, state.gamutHighlightEnabled ? 1 : 0);
+    off = packI32(view, off, 0); // _pad1
+    off = packI32(view, off, 0); // _pad2
+    packI32(view, off, 0); // _pad3
   }
 
   // WGSL struct: sharpenEnabled: u32, sharpenAmount: f32, texelSize: vec2f


### PR DESCRIPTION
## Summary

Five bug fixes from a fresh Wave 4 code audit. Each finding was independently verified before the fix (false positives filtered out).

| ID | Severity | Bug |
|---|---|---|
| **RENDER-W4-01** | HIGH | WebGPU `packSceneAnalysis()` packs uniforms in the wrong order vs the WGSL `Uniforms` struct in `scene_analysis.wgsl` — `gamutMappingEnabled` ends up where `toneMappingOperator` belongs, and `hdrHeadroom + _pad0` are skipped entirely. Tone-mapping operator selection on the WebGPU backend is silently broken. |
| **COLOR-W4-02** | MED | `applyLUT3D` / `applyLUT1D` divide by `(domainMax - domainMin)` without guarding zero-width domains, producing NaN that contaminates the entire output (TetrahedralInterp already guards correctly). |
| **COLOR-W4-03** | LOW | LUT parser uses `parseFloat()` on `DOMAIN_MIN/MAX` lines without `Number.isFinite()` checks, so malformed `.cube` files load with NaN domains. |
| **SESSION-W4-01** | MED | `PlaybackEngine.updateMediabunnyPlayback()` issues `getFrameAsync().then()` whose closure captures `source` by reference; if the source is swapped (or engine disposed) before the promise resolves, the stale callback writes to the wrong buffer. |
| **PLUGIN-W4-01** | MED | `topologicalSort()` doesn't filter disposed plugins, so activating a plugin whose declared dep is disposed throws the misleading `cannot be reactivated` error from a different code path instead of a clear `depends on "X" which is disposed`. |
| **NODE-W4-06** | LOW | `IPNode` forwards `propertyChanged` as `emit(data, data)` instead of `emit(newData, oldData)`, so subscribers diffing old vs. new always see identical objects. |

## Tests

Each fix ships with regression tests:
- `WebGPUStateUploader.test.ts`: 4 new (`WGPU-SU-138/139/13A/13B`) pin the byte layout via a named-offset map; existing `WGPU-SU-137` updated to the corrected layout
- `LUTLoader.test.ts`: 9 new (4 zero-width-domain + 5 parser validation)
- `PlaybackEngine.test.ts`: 5 new (source swap, dispose mid-flight, balanced buffering count in success/error paths, happy path)
- `PluginRegistry.test.ts`: 2 new (clear disposed-dep error + indirect topologicalSort verification)
- `IPNode.test.ts`: 1 new (`NODE-W4-06`) + 1 updated (`IPNODE-DISP-001` had hardcoded the buggy expectation)

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run src/render/webgpu/ src/color/ src/core/session/PlaybackEngine.test.ts src/plugin/ src/nodes/` → **3096 / 3096 pass** (98 files)
- `pnpm test:gpu` → 158/158 pass (RENDER-W4-01 cross-checked against the live WGSL via `tonemap-webgpu.gpu-test.ts`)

## Audit notes

The audit was run as 5 parallel agents covering distinct code areas (render, session/playback, formats, nodes/color, UI/plugin/compat/network). Total raw findings: 26 (1 HIGH, 11 MED, 14 LOW). After verification only these 5 were confirmed real bugs worth fixing in this PR; the rest were either:
- already fixed under prior IDs in `FIXED_ISSUES.md` (e.g., a finding around `CacheLUTNode` tint formula was actually MED-48-style behaviour and intentional — `tint*0.05` for R/B vs `tint*0.1` for G is the symmetric ±tintScale split)
- or low-impact edge cases (XMP path is already well-guarded, OutsideClickRegistry race condition is bounded, etc.)

## Test plan
- [x] `tsc --noEmit` passes
- [x] Affected unit suites pass (3096 tests)
- [x] GPU integration tests pass
- [ ] CI green
- [ ] No regressions in WebGPU rendering when toggling tone-mapping operators (manual smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)