### PR TITLE
fix: Wave 4 second pass — context-restore dirty flags + scope FBO log

### DIFF
--- a/src/render/Renderer.contextLoss.test.ts
+++ b/src/render/Renderer.contextLoss.test.ts
@@ -313,4 +313,24 @@ describe('Renderer WebGL Context Loss Recovery', () => {
     // Reset isTexture to default for subsequent tests
     (mockGL.isTexture as ReturnType<typeof vi.fn>).mockReturnValue(true);
   });
+
+  // -----------------------------------------------------------------------
+  // RENDER-W4-05: shader uniforms re-uploaded after context restore
+  // -----------------------------------------------------------------------
+
+  it('RENDER-W4-05: should mark all shader state dirty after context restore', () => {
+    // The dirty flags get cleared as applyUniforms() runs during normal frames.
+    // After a new GL context is created the existing program is gone; the
+    // freshly initShaders()-created program has no uniforms set. If
+    // ShaderStateManager's dirty flags weren't reset, the next render would
+    // skip the upload and the new program would render with default uniforms
+    // until the user touches a slider.
+    const stateManager = (renderer as unknown as { stateManager: { markAllDirty: () => void } }).stateManager;
+    const markAllDirtySpy = vi.spyOn(stateManager, 'markAllDirty');
+
+    canvas.dispatchEvent(new Event('webglcontextlost'));
+    canvas.dispatchEvent(new Event('webglcontextrestored'));
+
+    expect(markAllDirtySpy).toHaveBeenCalled();
+  });
 });

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -535,6 +535,12 @@ export class Renderer implements RendererBackend {
     this.initShaders();
     this.initQuad();
 
+    // Force every uniform / GL state field to re-upload on the next render.
+    // The new GL context starts with default values, but our dirty flags were
+    // cleared by prior applyUniforms() calls — without this, sliders changed
+    // *during* the loss window stay stale until the user touches them again.
+    this.stateManager.markAllDirty();
+
     log.info('GPU state re-initialized after context restore');
   }
 
@@ -1762,6 +1768,7 @@ export class Renderer implements RendererBackend {
     gl.bindTexture(gl.TEXTURE_2D, null);
 
     if (status !== gl.FRAMEBUFFER_COMPLETE) {
+      log.warn('Scope FBO not complete, status:', status);
       gl.deleteFramebuffer(fbo);
       gl.deleteTexture(texture);
       return;

--- a/src/render/StateAccessor.ts
+++ b/src/render/StateAccessor.ts
@@ -262,6 +262,14 @@ export interface StateAccessor {
    */
   applyUniforms(shader: ShaderProgram, texCb: TextureCallbacks): void;
 
+  /**
+   * Force every uniform to re-upload on the next applyUniforms() call.
+   * Called by the Renderer after a WebGL context restore: the new GL context
+   * starts with default uniform values but the dirty flags were already
+   * cleared by prior frames, so without this state would silently desync.
+   */
+  markAllDirty(): void;
+
   // --- Texture data access (replaces getInternalState() coupling) ---
 
   /** Get the current curves LUT texture data and dirty state. */


### PR DESCRIPTION
## Summary

Two render-pipeline robustness fixes from the second-pass review of deferred Wave 4 findings.

| ID | Severity | Fix |
|---|---|---|
| **RENDER-W4-05** | MED | After `webglcontextrestored`, the new GL context has default uniform values but `ShaderStateManager`'s dirty flags were already cleared by prior frames, so the next `applyUniforms()` skipped the upload and the program ran with stale defaults until the user touched a slider. `reinitializeAfterContextRestore()` now calls `stateManager.markAllDirty()`. |
| **RENDER-W4-06** | LOW | Scope FBO completeness check silently returned on incomplete status while the display HDR FBO logs a warning. Added a matching `log.warn` so driver-specific scope-rendering failures are visible in the field. |

The existing JSDoc on `ShaderStateManager`'s dirty flags literally said `"Reset on context restore (markAllDirty)"` — the call site was just missing. Also adds `markAllDirty()` to the `StateAccessor` interface (the implementation already existed).

## Triage notes — what was deferred from the original 26 findings

After verification, three more deferred findings were skipped as **false positives**:
- **RENDER-W4-02** (scope PBO format flip race): `disposeScopePBOs()` already nullifies *both* `scopePBOCachedPixels` and `scopePBOCachedPixelsUint8` on format change. No race exists.
- **RENDER-W4-04** (sync readPixels vs async PBO): The first-frame fallback `readPixels` writes to a CPU `Float32Array`, not a PBO — there's no shared buffer for the async path to race against.
- **PLUGIN-W4-02** (registerTool error message): The error literally says `'PaintEngine not yet initialized; call PluginRegistry.setPaintEngine() during bootstrap'`. The agent's claim that the error doesn't tell developers what to do was wrong.
- **FMT-W4-01** (gainmap NaN/Infinity at reconstruction): Both producer paths are guarded — `parseXMPArray` rejects on `Number.isFinite(val) === false`, and `parseTmapBox` reads `uint32` numerator/denominator with explicit zero-divisor branch (returns 0). No defensive clamp needed.

## Tests

- `Renderer.contextLoss.test.ts` — added `RENDER-W4-05` test that spies on `stateManager.markAllDirty` and verifies it's called after `webglcontextrestored`.
- All other context-loss tests still pass.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run src/render/` → **1797 / 1797 pass** (45 files), including the new regression test
- Prettier clean

## Test plan
- [x] tsc clean
- [x] full render suite passes
- [x] regression test added for W4-05
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)