### PR TITLE
fix(e2e): unbreak matrix shards by inlining PLAYBACK_SPEED_PRESETS

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E tests (shard ${{ matrix.shard }}/6)
+      - name: Run E2E tests (shard ${{ matrix.shard }}/5)
         run: pnpm test:e2e:ci --shard=${{ matrix.shard }}/5 --reporter=json --reporter=html
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: results.json

--- a/e2e/playback-edge-cases.spec.ts
+++ b/e2e/playback-edge-cases.spec.ts
@@ -16,7 +16,11 @@ import {
   waitForPlaybackSpeed,
   waitForCondition,
 } from './fixtures';
-import { PLAYBACK_SPEED_PRESETS } from '../src/core/session/Session';
+
+// Mirrors src/config/PlaybackConfig.ts. Inlined to keep e2e specs from
+// importing app source — Playwright's TS loader walks the import graph
+// and the @decorated classes downstream of Session.ts trip its Babel.
+const PLAYBACK_SPEED_PRESETS = [0.1, 0.25, 0.5, 1, 2, 4, 8] as const;
 
 /**
  * Playback Edge Cases Tests

--- a/src/config/Config.test.ts
+++ b/src/config/Config.test.ts
@@ -109,6 +109,13 @@ describe('PlaybackConfig', () => {
     expect(PLAYBACK_SPEED_PRESETS).toContain(1);
   });
 
+  // Drift guard: e2e/playback-edge-cases.spec.ts inlines this literal to keep
+  // Playwright's TS loader from walking through Session.ts into decorated
+  // node classes. If you change the source, update the inlined copy too.
+  it('PLAYBACK_SPEED_PRESETS literal matches the e2e spec inlined copy', () => {
+    expect(Array.from(PLAYBACK_SPEED_PRESETS)).toEqual([0.1, 0.25, 0.5, 1, 2, 4, 8]);
+  });
+
   it('MAX_CONSECUTIVE_STARVATION_SKIPS is a positive integer', () => {
     expect(typeof MAX_CONSECUTIVE_STARVATION_SKIPS).toBe('number');
     expect(MAX_CONSECUTIVE_STARVATION_SKIPS).toBeGreaterThan(0);

--- a/src/utils/input/KeyBindings.ts
+++ b/src/utils/input/KeyBindings.ts
@@ -5,7 +5,7 @@
  * Each shortcut maps to an action name that the KeyboardManager will dispatch to.
  */
 
-import { type KeyCombination } from './KeyboardManager';
+import type { KeyCombination } from './KeyboardManager';
 import type { BindingContext } from './ActiveContextManager';
 
 export interface KeyBindingEntry extends KeyCombination {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    // useDefineForClassFields:true gives ES2022 class fields [[Define]]
+    // semantics: every typed field — even uninitialized like `foo: string;` —
+    // installs an own data property on the instance, shadowing anything an
+    // ancestor or constructor installed via Object.defineProperty. Node
+    // classes in src/nodes/ rely on runtime accessors installed by
+    // defineNodeProperty()/properties.add(), so any subclass that wants to
+    // type-expose those accessors MUST use `declare foo: T` (no initializer)
+    // to suppress the field emission. See FileSourceNode.ts for the pattern.
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
## Summary

E2E matrix shards 1–5 have been failing on every master push since `@playwright/test` resolved to 1.57.0. The workflow-level conclusion was masking it (`continue-on-error: true` on the matrix job), but GitHub's commit-status panel showed all five shards red.

**Root cause.** Playwright 1.57's bundled Babel mis-orders plugins on classes that have *both* a class decorator and `declare` class fields:

\`\`\`
SyntaxError: src/nodes/sources/FileSourceNode.ts: TypeScript 'declare' fields
must first be transformed by @babel/plugin-transform-typescript.
> 559 |   declare url: string;
\`\`\`

\`FileSourceNode\` has \`@RegisterNode(...)\` + \`declare\` fields. \`e2e/playback-edge-cases.spec.ts\` imported a value from \`src/core/session/Session\`, which transitively pulled \`FileSourceNode\` into Playwright's TS loader graph.

## Changes

- **\`e2e/playback-edge-cases.spec.ts\`** — Replace the runtime import from \`../src/core/session/Session\` with an inlined \`PLAYBACK_SPEED_PRESETS = [0.1, 0.25, 0.5, 1, 2, 4, 8] as const\`.
- **\`src/config/Config.test.ts\`** — Drift guard: asserts the canonical source array equals the inlined literal. If anyone changes \`src/config/PlaybackConfig.ts\` without updating the spec, this test fails in the unit shard.
- **\`src/utils/input/KeyBindings.ts\`** — Switch \`import { type KeyCombination }\` to \`import type { KeyCombination }\`. Makes the leaf-safety of \`shortcut-helper.ts\`'s import chain unmistakable.
- **\`tsconfig.json\`** — Document why \`useDefineForClassFields: true\` requires \`declare\` on node-class subclasses (they install runtime accessors via \`defineNodeProperty()\`).
- **\`.github/workflows/e2e.yml\`** — Cosmetic: step name said \`shard X/6\` while the flag was \`--shard=X/5\`.

## Verified

- \`npx tsc --noEmit\` clean
- \`npx vitest run src/config/Config.test.ts\` — 24 passed (drift guard added)
- \`npx playwright test --list e2e/playback-edge-cases.spec.ts\` — all 35 tests enumerate cleanly (was a hard Babel error before)

## Out of scope (follow-ups)

- The \`continue-on-error: true\` on \`e2e.yml:63\` and the unconditional exit-0 in \`e2e-report\` still let the workflow report \`success\` when shards are red. \`coverage.yml:42,58–60\` has the correct pattern to copy.
- \`e2e.yml:99\` writes \`results.json\` from every shard with the same filename — \`download-artifact\` with \`merge-multiple: true\` overwrites, so the 80% pass-rate check is computed from one shard's stats.
- \`gpu-tests.yml:26\` has the same masking pattern.
- Many sibling node classes (\`VideoSourceNode\`, group nodes, \`CacheLUTNode\`) call \`defineNodeProperty()\` without ever using \`declare\` — works today only because they don't type-expose the property.

## Test plan

- [x] Unit shard passes locally (Config.test.ts +1 test)
- [x] Playwright loads the spec without a Babel error
- [ ] CI: E2E shards 1–5 should now turn green
- [ ] CI: GPU + Coverage should remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)